### PR TITLE
Fix async next for sync hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ console.log(result); // 4
 ```
 
 _Note: You should always use `sync` if you are returning a value.  This includes if you are returning a `Promise`.
-If you're hooking a function with `sync` your hooks **must** call `next` synchronously (e.g. no ajax).  Calling
-`next` asynchronously can lead to unpredictable behavior, including an `undefined` return value and incorrect
-arguments passed to subsequent hooks or the wrapped function._
+If you're hooking a function with `sync` your hooks **must** call `next` synchronously (e.g. no ajax).
 
 ### Async (`before`, `after`)
 ```javascript

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ let result = hookedSum(1, 1);
 console.log(result); // 4
 ```
 
-_Note: You should always use `sync` if you are returning a value.  This includes if you are returning a `Promise`.
-If you're hooking a function with `sync` your hooks **must** call `next` synchronously (e.g. no ajax).
+_Note: You should always use `sync` if you are returning a value. This includes if you are returning a `Promise`.
+69  If you're hooking a function with `sync` your hooks **must** call `next` synchronously (e.g. no ajax). Calling
+70  `next` asynchronously can lead to unpredictable behavior, including an `undefined` return value and incorrect
+71  arguments passed to subsequent hooks or the wrapped function._
 
 ### Async (`before`, `after`)
 ```javascript

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ let result = hookedSum(1, 1);
 console.log(result); // 4
 ```
 
-_Note: You should always use `sync` if you are returning a value.  This includes if you are returning a `Promise`.  
-Also, if you're hooking a function with `sync` your hooks should all call `next` synchronously (e.g. no ajax) so that 
-your value can be returned.  If you asynchronously call `next` in a `sync` hook then the return value will be 
-`undefined`._
+_Note: You should always use `sync` if you are returning a value.  This includes if you are returning a `Promise`.
+If you're hooking a function with `sync` your hooks **must** call `next` synchronously (e.g. no ajax).  Calling
+`next` asynchronously can lead to unpredictable behavior, including an `undefined` return value and incorrect
+arguments passed to subsequent hooks or the wrapped function._
 
 ### Async (`before`, `after`)
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,11 @@ export interface CreateHook {
   <T extends Fn>(fn: T): SyncHook<T>;
   <T extends Fn>(type: "sync", fn: T, name?: string): SyncHook<T>;
   <T extends Fn>(type: "async", fn: T, name?: string): AsyncHook<T>;
-  <Hooks extends {[key: string]: any}, T extends object = object>(obj: T, props: string[], name?: string): Hooks;
+  <Hooks extends { [key: string]: any }, T extends object = object>(
+    obj: T,
+    props: string[],
+    name?: string
+  ): Hooks;
   get<T>(name: string): T;
 }
 

--- a/index.js
+++ b/index.js
@@ -310,6 +310,7 @@ function create(config) {
         targetIndex = order.push(undefined) - 1;
         after.forEach(addToOrder);
         trap = function(target, thisArg, args) {
+          var localOrder = order.slice();
           var curr = 0;
           var result;
           var callback =
@@ -324,11 +325,11 @@ function create(config) {
             }
           }
           function next(value) {
-            if (order[curr]) {
+            if (localOrder[curr]) {
               var args = rest(arguments);
               next.bail = bail;
               args.unshift(next);
-              return order[curr++].apply(thisArg, args);
+              return localOrder[curr++].apply(thisArg, args);
             }
             if (type === "sync") {
               result = value;
@@ -336,7 +337,7 @@ function create(config) {
               callback.apply(null, arguments);
             }
           }
-          order[targetIndex] = function() {
+          localOrder[targetIndex] = function() {
             var args = rest(arguments, 1);
             if (type === "async" && callback) {
               delete next.bail;

--- a/index.test.js
+++ b/index.test.js
@@ -581,7 +581,6 @@ describe.each(creates)("%s", (_, create) => {
     ]);
   });
 
-
   test("allows hooking objects (and prototypes)", () => {
     let hook = create(config);
 

--- a/index.test.js
+++ b/index.test.js
@@ -553,6 +553,35 @@ describe.each(creates)("%s", (_, create) => {
     expect(order).toEqual([1, 2, 3, 4, "fn", 5, 6, 7, 8, 9]);
   });
 
+  test("async calls to next in sync hooks should not mix arguments", () => {
+    jest.useFakeTimers();
+    let hook = create(config);
+    let log = [];
+
+    let hooked = hook("sync", a => {
+      log.push(["inner", a]);
+    });
+
+    hooked.before((next, a) => {
+      log.push(["outer", a]);
+      setTimeout(() => next(a), 0);
+    });
+
+    hooked(1);
+    hooked(2);
+
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    expect(log).toEqual([
+      ["outer", 1],
+      ["outer", 2],
+      ["inner", 1],
+      ["inner", 2]
+    ]);
+  });
+
+
   test("allows hooking objects (and prototypes)", () => {
     let hook = create(config);
 


### PR DESCRIPTION
## Summary
- ensure hook ordering isn't overwritten by parallel calls
- clarify sync hook requirements in README
- test asynchronous calls to `next` for sync hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841cf1f89d4832b90a835b74da10a77